### PR TITLE
Adds a normal numeric keyboard

### DIFF
--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -7,7 +7,10 @@
           v-model="$v.weight.$model"
           :placeholder="$t('weight-placeholder')"
           :class="{ 'is-danger': !$v.weight.minValue }"
-          class="input" type="number"
+          class="input" 
+          type="number"
+          pattern="[0-9]*"
+          inputmode="decimal"
         >
         <p v-if="!$v.weight.minValue" class="help is-danger">
           {{ $t('Minimal') }}: {{ $v.weight.$params.minValue.min }}
@@ -23,6 +26,8 @@
           :class="{ 'is-danger': !$v.price.minValue }"
           class="input"
           type="number"
+          pattern="[0-9]*"
+          inputmode="decimal"
         >
         <p v-if="!$v.price.minValue" class="help is-danger">
           {{ $t('Minimal') }}: {{ $v.price.$params.minValue.min }}


### PR DESCRIPTION
Now on mobile devices it shows big numeric keyboards with small buttons and with unnecessary symbols. It's better to show only numbers and decimal separator.   
It can be achieved with `pattern="[0-9]*"` and `inputmode="decimal"` attributes on `input`.

As is:
![image](https://user-images.githubusercontent.com/5827605/63218451-bdb21b00-c163-11e9-88ad-2c04ef69545a.png)

To be:
![image](https://user-images.githubusercontent.com/5827605/63218454-da4e5300-c163-11e9-9ee2-007b0efbf175.png)

More info:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
https://css-tricks.com/finger-friendly-numerical-inputs-with-inputmode/
